### PR TITLE
Remove peer dep on loopback-datasource-juggler

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
     "JSONPath": "~0.10.0",
     "debug": "~0.8.0"
   },
-  "peerDependencies": {
-    "loopback-datasource-juggler": "1.x.x"
-  },
   "devDependencies": {
     "loopback-datasource-juggler": "1.x.x",
     "loopback": "1.x.x",


### PR DESCRIPTION
The connector does not require anything from the juggler at all.

See strongloop/loopback#275 for more details about this change.

/to @raymondfeng Please review. Could you also add me as an owner of the package on npmjs.org? I'll release this change as a new minor version.
