### PR TITLE
Support specifying rest resource name

### DIFF
--- a/lib/rest-connector.js
+++ b/lib/rest-connector.js
@@ -105,7 +105,7 @@ RestConnector.prototype.define = function defineModel(definition) {
   var m = definition.model.modelName;
   this.installPostProcessor(definition);
   this._models[m] = definition;
-  this._resources[m] = new RestResource(definition.model.pluralModelName, this._baseURL);
+  this._resources[m] = new RestResource(definition.settings.resourceName || definition.model.pluralModelName, this._baseURL);
 };
 
 /**


### PR DESCRIPTION
Add support to specify the resource name (name of model on rest endpoint) instead of forcing it to be the pluralModelName.

Signed-off-by: Lance Hudson lance@lancehudson.com
