### PR TITLE
 Support form data and allow to parse response as json

### DIFF
--- a/lib/rest-builder.js
+++ b/lib/rest-builder.js
@@ -473,9 +473,10 @@ RequestBuilder.prototype.invoke = function (parameters, cb) {
     uri: json.url,
     qs: json.query,
     json: json.json,
+    form: json.form,
     headers: json.headers,
     timeout: json.timeout
-  }
+  };
 
   if (json.body !== undefined) {
     req.body = json.body;


### PR DESCRIPTION
In case that upstream api doesn't follow the HTTP spec. So we can
force to parse response body as json.

Signed-off-by: Clark Wang clark.wangs@gmail.com
