### PR TITLE
Allow hyphen seperated template variables

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -47,12 +47,12 @@ JsonTemplate.prototype.compile = function() {
 
     function parse(item) {
       let matched = false;
-      const templates = /\{(([\!\^]?[a-zA-Z\$_][\w\$]*)\s*(=([^:]+))?(:(\w+))?)\}/g;
+      const templates = /\{(([\!\^]?[a-zA-Z\$_][\w\$-]*)\s*(=([^:]+))?(:(\w+))?)\}/g;
       /* eslint-disable no-cond-assign */
       while (match = templates.exec(item)) {
         /* eslint-enable no-cond-assign */
         matched = true;
-        const param = /([[\!\^]?[a-zA-Z\$_][\w\$]*)\s*(=([^:]+))?(:(\w+))?/.exec(match[1]);
+        const param = /([[\!\^]?[a-zA-Z\$_][\w\$-]*)\s*(=([^:]+))?(:(\w+))?/.exec(match[1]);
         if (!param || !param[1]) {
           throw new Error(g.f('Invalid parameter: %s', match[1]));
         }
@@ -120,7 +120,7 @@ JsonTemplate.prototype.build = function(parameters) {
   function transform(obj) {
     return traverse(obj).map(function(item) {
       const ctx = this;
-      const templates = /\{(([\!\^]?[a-zA-Z\$_][\w\$]*)\s*(=([^:\{\}]+))?(:(\w+))?)\}/g;
+      const templates = /\{(([\!\^]?[a-zA-Z\$_][\w\$-]*)\s*(=([^:\{\}]+))?(:(\w+))?)\}/g;
       function build(item) {
         let match = null;
         const parsed = [];
@@ -134,7 +134,7 @@ JsonTemplate.prototype.build = function(parameters) {
             parsed.push(item.substring(index, match.index));
           }
           // The variable pattern is {name=defaultValue:type}
-          const param = /([\!\^]?[a-zA-Z\$_][\w\$]*)\s*(=([^:\{\}]+))?(:(\w+))?/.exec(match[1]);
+          const param = /([\!\^]?[a-zA-Z\$_][\w\$-]*)\s*(=([^:\{\}]+))?(:(\w+))?/.exec(match[1]);
           if (!param || !param[1]) {
             throw new Error(g.f('Invalid parameter: %s', match[1]));
           }


### PR DESCRIPTION
Allowing template variables like ^foo-bar=barbar:string.
This was causing an error  `Cannot initialize connector "rest": Cannot read property 'type' of undefined' at boot.`
https://regex101.com/r/HoCufm/1

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
