### PR TITLE
docs: add loopback 4 usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 The LoopBack REST connector enables applications to interact with other (third party) REST APIs using a template-driven approach.
 It supports two different styles of API invocations:
 
-* [Resource operations](#resource-operations)
-* [Defining a custom method using a template](#defining-a-custom-method-using-a-template)
+- [Resource operations](#resource-operations)
+- [Defining a custom method using a template](#defining-a-custom-method-using-a-template)
 
 ## Installation
 
@@ -46,6 +46,16 @@ This adds an entry to [datasources.json](http://loopback.io/doc/en/lb3/datasour
 ...
 ```
 
+## LoopBack 4 Usage
+
+1. Create a LoopBack 4 DataSource with REST connector using the `lb4 datasource` command.
+
+2. Create a service that maps to the operations using the `lb4 service` command.
+
+3. Create a controller that calls the service created in the above step using `lb4 controller` command.
+
+For details, refer to the [Calling REST APIs documentation page](https://loopback.io/doc/en/lb4/Calling-rest-apis.html).
+
 ## Configuring a REST data source
 
 Configure the REST connector by editing `datasources.json` manually (for example using the Google Maps API):
@@ -81,10 +91,10 @@ Configure the REST connector by editing `datasources.json` manually (for examp
 
 The `operations` property is an array of objects, each of which can have these properties:
 
-* `template`: An object that defines a custom method using a template; see [Defining a custom method using a template](#defining-a-custom-method-using-a-template).
-* `functions`: An object that maps a JavaScript function to a list of parameter names.  
+- `template`: An object that defines a custom method using a template; see [Defining a custom method using a template](#defining-a-custom-method-using-a-template).
+- `functions`: An object that maps a JavaScript function to a list of parameter names.
 
-The example above creates a function `geocode(street, city, zipcode)` whose first argument is `street`, second is `city`, and third is `zipcode`.  LoopBack application code can call the function anywhere; for example, in a boot script, via  middleware, or within a model's JavaScript file if attached to the REST datasource. 
+The example above creates a function `geocode(street, city, zipcode)` whose first argument is `street`, second is `city`, and third is `zipcode`.  LoopBack application code can call the function anywhere; for example, in a boot script, via middleware, or within a model's JavaScript file if attached to the REST datasource.
 
 ## Configure options for request
 
@@ -94,8 +104,8 @@ See [`request(options, callback)`](https://www.npmjs.com/package/request#reques
 
 You can configure options `options` property at two levels:
 
-* Data source level (common to all operations)
-* Operation level (specific to the declaring operation)
+- Data source level (common to all operations)
+- Operation level (specific to the declaring operation)
 
 The following example sets `Accept` and `Content-Type` to `"application/json"` for all requests.
 It also sets `strictSSL` to false so the connector allows self-signed SSL certificates.
@@ -143,53 +153,59 @@ you can simply bind the model to a REST endpoint that follows REST conventions.
 
 For example, the following methods would be mixed into your model class:
 
-* create: `POST /users`
-* findById: `GET /users/:id`
-* delete: `DELETE /users/:id`
-* update: `PUT /users/:id`
-* find: `GET /users?limit=5&username=ray&order=email`
+- create: `POST /users`
+- findById: `GET /users/:id`
+- delete: `DELETE /users/:id`
+- update: `PUT /users/:id`
+- find: `GET /users?limit=5&username=ray&order=email`
 
 For example:
 
 **/server/boot/script.js**
 
 ```javascript
-module.exports = function(app) {
+module.exports = function (app) {
   var ds = app.loopback.createDataSource({
     connector: require("loopback-connector-rest"),
     debug: false,
-    baseURL: 'http://localhost:3000'
+    baseURL: "http://localhost:3000",
   });
 
-  var User = ds.createModel('user', {
+  var User = ds.createModel("user", {
     name: String,
     bio: String,
     approved: Boolean,
     joinedAt: Date,
-    age: Number
+    age: Number,
   });
 
-  User.create(new User({
-    name: 'Mary'
-  }), function(err, user) {
+  User.create(
+    new User({
+      name: "Mary",
+    }),
+    function (err, user) {
+      console.log(user);
+    }
+  );
+
+  User.find(function (err, user) {
     console.log(user);
   });
 
-  User.find(function(err, user) {
-    console.log(user);
-  });
-
-  User.findById(1, function(err, user) {
+  User.findById(1, function (err, user) {
     console.log(err, user);
   });
 
-  User.update(new User({
-    id: 1,
-    name: 'Raymond'
-  }), function(err, user) {
-    console.log(err, user);
-  });
-}
+  User.update(
+    new User({
+      id: 1,
+      name: "Raymond",
+    }),
+    function (err, user) {
+      console.log(err, user);
+    }
+  );
+};
 ```
 
 ### Setting the resource URL
@@ -201,12 +217,12 @@ For example:
 
 ```javascript
 var config = {
-  "name": "ServiceTransaction",
-  "base": "PersistedModel",
-  "resourceName": "transactions"
-}
+  name: "ServiceTransaction",
+  base: "PersistedModel",
+  resourceName: "transactions",
+};
 
-var ServiceTransaction = ds.createModel('ServiceTransaction', {}, config);
+var ServiceTransaction = ds.createModel("ServiceTransaction", {}, config);
 ```
 
 Now there will be a resource model named `ServiceTransaction`, but whose URLs call out to `baseUrl - '/transactions'`
@@ -217,14 +233,14 @@ Without setting `resourceName` the calls would have been made to `baseUrl - '
 
 The `template` object specifies the REST API invocation as a JSON template, with the following properties:
 
-| Property | Description | Type |
-|----------|-------------|------|
-| `method`| HTTP method | String (one of "GET", "POST", "PUT", and so on). |
-| `url`| The URL of the request | String; template values allowed. |
-| `headers`| HTTP headers | Object |
-| `query`| Query strings | Object; template values allowed. |
-| `responsePath`| Optional JSONPath applied to the HTTP body. See [https://github.com/s3u/JSONPath](https://github.com/s3u/JSONPath) for syntax of JSON paths.| String |
-| `fullResponse`| Optional flag to return full response, rather than just body. | Boolean |
+| Property       | Description                                                                                                                                  | Type                                             |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `method`       | HTTP method                                                                                                                                  | String (one of "GET", "POST", "PUT", and so on). |
+| `url`          | The URL of the request                                                                                                                       | String; template values allowed.                 |
+| `headers`      | HTTP headers                                                                                                                                 | Object                                           |
+| `query`        | Query strings                                                                                                                                | Object; template values allowed.                 |
+| `responsePath` | Optional JSONPath applied to the HTTP body. See [https://github.com/s3u/JSONPath](https://github.com/s3u/JSONPath) for syntax of JSON paths. | String                                           |
+| `fullResponse` | Optional flag to return full response, rather than just body.                                                                                | Boolean                                          |
 
 The template variable syntax is:
 
@@ -289,7 +305,7 @@ The following table provides several examples:
 
 To use custom methods, configure the REST connector with the `operations` property, which is an array of objects, each of which can have these properties:
 
-- `template` defines the API structure. 
+- `template` defines the API structure.
 - `functions` defines JavaScript methods that accept the specified list of parameter names.
 
 ```javascript
@@ -298,37 +314,42 @@ var loopback = require("loopback");
 var ds = loopback.createDataSource({
   connector: require("loopback-connector-rest"),
   debug: false,
-  operations: [{
-    template: {
-      "method": "GET",
-      "url": "http://maps.googleapis.com/maps/api/geocode/{format=json}",
-      "headers": {
-        "accepts": "application/json",
-        "content-type": "application/json"
+  operations: [
+    {
+      template: {
+        method: "GET",
+        url: "http://maps.googleapis.com/maps/api/geocode/{format=json}",
+        headers: {
+          accepts: "application/json",
+          "content-type": "application/json",
+        },
+        query: {
+          address: "{street},{city},{zipcode}",
+          sensor: "{sensor=false}",
+        },
+        responsePath: "$.results[0].geometry.location",
       },
-      "query": {
-        "address": "{street},{city},{zipcode}",
-        "sensor": "{sensor=false}"
+      functions: {
+        geocode: ["street", "city", "zipcode"],
       },
-      "responsePath": "$.results[0].geometry.location"
     },
-    functions: {
-      "geocode": ["street", "city", "zipcode"]
-    }
-  }]
+  ],
 });
 ```
 
 Now you can invoke the geocode API in Node.js as follows:
 
 ```javascript
-Model.geocode('107 S B St', 'San Mateo', '94401', processResponse);
+Model.geocode("107 S B St", "San Mateo", "94401", processResponse);
 ```
 
 By default, the REST connector also provides an 'invoke' method to call the REST API with an object of parameters, for example:
 
 ```javascript
-Model.invoke({street: '107 S B St', city: 'San Mateo', zipcode: '94401'}, processResponse);
+Model.invoke(
+  { street: "107 S B St", city: "San Mateo", zipcode: "94401" },
+  processResponse
+);
 ```
 
 ## Parameter/variable mapping to HTTP (since 2.0.0)
@@ -397,9 +418,9 @@ You can further customize the source in the parameter array of the function mapp
 
 For the template above, the variables will be mapped as follows:
 
-* p - path
-* x - query
-* a - body
-* b - header
+- p - path
+- x - query
+- a - body
+- b - header
 
 Please note that path variables are appended to the path, for example, `/myOp/:p.`


### PR DESCRIPTION
[REST Connector](https://loopback.io/doc/en/lb4/REST-connector.html) page lacked the loopback 4 usage instructions. 
And loopback 2.x and 3.x usage doesn't hint much about possible steps for LB4.

So I added the instructions and linked details page of [calling REST APIs](https://loopback.io/doc/en/lb4/Calling-rest-apis.html).


Signed-off-by: Shubham Prajapat <shubham.prajapat@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
