### PR TITLE
chore: update renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>loopbackio/cicd//shared-configs/renovate/base"
+    ":dependencyDashboard",
+    ":semanticPrefixFixDepsChoreOthers",
+    ":gitSignOff",
+    ":ignoreModulesAndTests",
+    ":prConcurrentLimit10",
+    "workarounds:typesNodeVersioning"
+  ],
+  "lockFileMaintenance": {
+    "extends": [
+      "schedule:monthly"
+    ],
+    "enabled": true,
+    "automerge": true
+  }
 }


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

The renovate bot doesn't seem to work in this repo. Updating the `renovate.json` to be the same as https://github.com/loopbackio/loopback-connector-postgresql/blob/master/renovate.json. 


## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
