### PR TITLE
fix: update js-traverse version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "loopback-connector-rest",
-      "version": "5.0.7",
+      "version": "5.0.8",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.0",
@@ -17,7 +17,7 @@
         "postman-request": "^2.88.1-postman.33",
         "qs": "^6.1.0",
         "strong-globalize": "^6.0.5",
-        "traverse": "^0.6.6"
+        "traverse": "^0.6.8"
       },
       "devDependencies": {
         "@commitlint/config-conventional": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "postman-request": "^2.88.1-postman.33",
     "qs": "^6.1.0",
     "strong-globalize": "^6.0.5",
-    "traverse": "^0.6.6"
+    "traverse": "^0.6.8"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^19.0.0",


### PR DESCRIPTION
The commit f35cae fixed symbol issues, but
that fix is only implemented on js-traverse
version `0.6.8` and upwards. So we lift the
minimum version to fix the issue properly.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
