### PR TITLE
chore: drop Node.js 20 support

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 26]
     steps:
     - name: Git checkout
       uses: actions/checkout@v6
@@ -31,10 +31,10 @@ jobs:
       timeout-minutes: 60
       steps:
         - uses: actions/checkout@v6
-        - name: Use Node.js 20
+        - name: Use Node.js 24
           uses: actions/setup-node@v6
           with:
-            node-version: 20
+            node-version: 24
         - name: Bootstrap project
           run: |
             npm ci --ignore-scripts
@@ -49,10 +49,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Use Node.js 20
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - name: Bootstrap project
         run: |
           npm ci --ignore-scripts

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "loopback-connector-rest",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.0",
@@ -33,7 +33,7 @@
         "should": "^13.2.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@commitlint/config-conventional": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.0.7",
   "description": "Loopback REST Connector",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "keywords": [
     "LoopBack",
@@ -46,5 +46,5 @@
     "url": "https://github.com/loopbackio/loopback-connector-rest.git"
   },
   "license": "MIT",
-  "author": "IBM Corp."
+  "author": "IBM Corp. and LoopBack contributors"
 }


### PR DESCRIPTION
BREAKING CHANGE: drop Node.js 20 support

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Node.js 20 has reached end of life (see https://github.com/nodejs/Release), so dropping its support in this module.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
